### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "lodash": "^4.17.11",
     "meteor-node-stubs": "^0.4.1",
     "music-metadata-browser": "^0.7.1",
-    "npm": "^6.9.0",
     "react": "^16.8.6",
     "react-apollo": "^2.5.5",
     "react-dom": "^16.8.6",


### PR DESCRIPTION

Hello GuillaumeBergeronGeoffroy!

It seems like you have npm as one of your (dev-) dependency in Sonocity.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
